### PR TITLE
polish: portfolio-grade README + repo metadata uplift (0.1.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "beads-superpowers",
       "description": "Superpowers skills + Beads issue tracking: TDD, debugging, collaboration, and persistent project management for AI agents",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "source": "./",
       "author": {
         "name": "Dillon Frawley"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beads-superpowers",
-  "description": "Superpowers skills + Beads issue tracking: TDD, debugging, collaboration, and persistent project management for AI agents",
-  "version": "0.1.0",
+  "description": "Claude Code plugin merging Superpowers skills with Beads issue tracking. 15 mandatory skills + persistent task memory for AI coding agents.",
+  "version": "0.1.1",
   "author": {
     "name": "Dillon Frawley"
   },

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Something in the plugin doesn't work as expected
+title: "[bug] "
+labels: ["bug", "needs-triage"]
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## Reproduction steps
+
+1. Install the plugin via `claude plugin install ...`
+2. Run `bd ...`
+3. Observe `...`
+
+## Expected behaviour
+
+What you expected to happen.
+
+## Actual behaviour
+
+What actually happened, including any error messages.
+
+## Environment
+
+- OS: (e.g. macOS 15.1, Ubuntu 24.04, Windows 11 + WSL2)
+- Claude Code version: (run `claude --version`)
+- Beads version: (run `bd --version`)
+- Plugin version: (from `.claude-plugin/plugin.json`)
+- Shell: (bash, zsh, fish, …)
+
+## Logs / output
+
+```text
+Paste any relevant terminal output here.
+```
+
+## Additional context
+
+Anything else that might be relevant — config snippets, the skill being invoked, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Read the documentation first
+    url: https://github.com/DollarDill/beads-superpowers#readme
+    about: The README, METHODOLOGY, and SETUP-GUIDE answer most questions.
+  - name: Upstream Superpowers
+    url: https://github.com/obra/superpowers
+    about: For issues with the upstream skill content itself.
+  - name: Upstream Beads
+    url: https://github.com/gastownhall/beads
+    about: For issues with the bd CLI or Dolt-backed storage.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest a new skill, workflow, or capability
+title: "[feature] "
+labels: ["enhancement", "needs-triage"]
+---
+
+## Problem
+
+What problem are you trying to solve? What does the current workflow miss?
+
+## Proposed solution
+
+What should the plugin do? If you're proposing a new skill, sketch the trigger
+condition and what the skill would enforce.
+
+## Alternatives considered
+
+What other approaches did you consider, and why did you reject them?
+
+## Additional context
+
+Links to upstream discussions, related skills, or examples from other plugins.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Summary
+
+<!-- One sentence: what does this PR change and why? -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New skill or feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would change existing behaviour)
+- [ ] Documentation only (README, CHANGELOG, METHODOLOGY, etc.)
+- [ ] Build / CI / tooling
+
+## Checklist
+
+- [ ] I have read [`CONTRIBUTING.md`](../CONTRIBUTING.md)
+- [ ] CI passes locally (`npx markdownlint-cli2 "**/*.md"`)
+- [ ] If I added or modified a skill, I did NOT add `TodoWrite` references — only `bd` commands
+- [ ] If I added or modified a skill, I did NOT remove anti-rationalization tables, Iron Laws, or Red Flags
+- [ ] If I changed plugin metadata, I bumped the version in all 3 manifests via `scripts/bump-version.sh`
+- [ ] I updated `CHANGELOG.md` under `## [Unreleased]`
+- [ ] I updated `README.md` if user-facing behaviour changed
+
+## Linked issue
+
+Closes #

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # GitHub Actions ecosystem — keeps CI workflow actions current
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Australia/Melbourne"
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # npm ecosystem — pre-registered for future-proofing (currently zero deps)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Australia/Melbourne"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint Markdown + Validate Plugin Manifest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lint markdown
+        uses: DavidAnson/markdownlint-cli2-action@v16
+        with:
+          globs: "**/*.md"
+
+      - name: Validate plugin.json (parses)
+        run: python3 -c "import json; json.load(open('.claude-plugin/plugin.json'))"
+
+      - name: Validate plugin.json (required keys present)
+        run: |
+          python3 <<'PY'
+          import json, sys
+          m = json.load(open('.claude-plugin/plugin.json'))
+          required = {'name', 'description', 'version', 'author', 'license'}
+          missing = required - set(m.keys())
+          if missing:
+              sys.exit(f'plugin.json missing required keys: {missing}')
+          print('plugin.json: all required keys present')
+          PY

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ docs/09-*.md
 
 # Session work logs (internal, not part of the plugin)
 SESSION-SUMMARY.md
+.sessions/
+.claude/session-log.jsonl
 
 # Dependencies
 node_modules/

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,26 @@
+// markdownlint-cli2 configuration
+// Note: .markdownlintignore is NOT supported by markdownlint-cli2; ignores go here.
+{
+  "config": {
+    "default": true,
+    "MD013": false,
+    "MD024": false,
+    "MD033": false,
+    "MD041": false,
+    "MD060": false
+  },
+  "ignores": [
+    // Upstream-derived skill content — not in scope for this repo's lint
+    "skills/**",
+    // Reference docs imported from upstream
+    "docs/upstream-reference/**",
+    // Test fixtures and test infrastructure
+    "tests/**",
+    // Local working files
+    ".sessions/**",
+    // Beads tool internal files (upstream-derived)
+    ".beads/**",
+    // Dependencies (if added in future)
+    "node_modules/**"
+  ]
+}

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,14 +1,11 @@
 // markdownlint-cli2 configuration
 // Note: .markdownlintignore is NOT supported by markdownlint-cli2; ignores go here.
+// Inherit rule config from .markdownlint.json so editor plugins
+// (which read .markdownlint.json) and CI (which reads
+// .markdownlint-cli2.jsonc) stay in sync. This file only adds
+// the cli2-specific ignores list.
 {
-  "config": {
-    "default": true,
-    "MD013": false,
-    "MD024": false,
-    "MD033": false,
-    "MD041": false,
-    "MD060": false
-  },
+  "extends": ".markdownlint.json",
   "ignores": [
     // Upstream-derived skill content — not in scope for this repo's lint
     "skills/**",

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,8 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD024": false,
+  "MD033": false,
+  "MD041": false,
+  "MD060": false
+}

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,14 @@
+# Upstream-derived skill content — not in scope for this repo's lint
+skills/
+
+# Reference docs imported from upstream
+docs/upstream-reference/
+
+# Test fixtures and test infrastructure
+tests/
+
+# Local working files
+.sessions/
+
+# Dependencies (if added in future)
+node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This project is a **Claude Code plugin** (beads-superpowers). It provides 15 ski
 
 This project uses **bd (beads)** for ALL issue tracking. Issues sync to GitHub Issues via `bd github sync`.
 
-- **GitHub Issues:** https://github.com/DollarDill/beads-superpowers/issues
+- **GitHub Issues:** <https://github.com/DollarDill/beads-superpowers/issues>
 - **Issue tracker:** `bd` CLI (beads) with GitHub sync
 - Do NOT use TodoWrite, TaskCreate, or markdown TODO lists
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+(none yet)
+
+## [0.1.1] - 2026-04-11
+
+### Added
+
+- `assets/banner.svg` — 1280×320 hero banner SVG (slate→indigo gradient, mono text, hexagon accent)
+- `.github/workflows/ci.yml` — markdownlint + plugin.json schema validation
+- `.github/dependabot.yml` — weekly grouped Dependabot for github-actions and npm
+- `.github/ISSUE_TEMPLATE/` — bug report and feature request templates plus blank-issue config
+- `.github/PULL_REQUEST_TEMPLATE.md` — PR checklist
+- `CONTRIBUTING.md` — contributor guide
+- `SECURITY.md` — vulnerability reporting policy (private disclosure via GitHub Security Advisories)
+- `.markdownlint.json`, `.markdownlint-cli2.jsonc`, and `.markdownlintignore` — lint config + scope (excludes upstream-derived skill content)
+- README hero band: banner image, tagline, badge row (license, version, CI, stars)
+- README dual-path block: "Try it in 60 seconds" + "Why it exists" side by side
+- README `## Architecture` section with Mermaid diagram and orchestrator-only design summary
+
 ### Changed
 
 - 5 skills refactored to use `AskUserQuestion` tool for structured user input instead of text-based prompts:
@@ -21,6 +39,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `writing-plans` now has an explicit User Review Gate section (plan approval) before the execution handoff
 - `using-git-worktrees` now enforces `bd worktree` commands over raw `git worktree` — added Iron Law section, command mapping table, and updated all creation/cleanup steps
 - `finishing-a-development-branch` Step 5 (worktree cleanup) updated to use `bd worktree info`/`bd worktree remove`
+- README restructured: hero band, badges, dual-path layout, Architecture section, trimmed project tree
+- `plugin.json` description rewritten to match the GitHub repo description (single source of truth)
+- `scripts/bump-version.sh` fixed: `declared_files()` was reading `.field` from `.version-bump.json` but the config uses `.key`, causing `null` keys to be written instead of updating versions
+- Default branch renamed from `master` → `main`
+
+### Deprecated
+
+- `commands/brainstorm.md`, `commands/execute-plan.md`, `commands/write-plan.md` slash command stubs — will be removed in **v0.2.0**. Use the corresponding skills via the `Skill` tool instead.
+
+### Moved
+
+- `SESSION-SUMMARY.md` working file is now gitignored. The `.sessions/` directory exists for future session-summary files but is not tracked. (`SESSION-SUMMARY.md` itself was never tracked in git.)
+
+### Security
+
+- GitHub-side toggles enabled: Dependabot alerts, Dependabot security updates, secret scanning, push protection
+- `SECURITY.md` policy added for private vulnerability disclosure
 
 ## [0.1.0] - 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Changed
+
 - 5 skills refactored to use `AskUserQuestion` tool for structured user input instead of text-based prompts:
   - `brainstorming` — multiple-choice clarifying questions, approach selection, section approval, spec review gate, visual companion offer
   - `finishing-a-development-branch` — branch completion options (merge/PR/keep/discard)
@@ -24,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [0.1.0] - 2026-04-06
 
 ### Added
+
 - Claude Code plugin infrastructure (`.claude-plugin/plugin.json`, hooks, package.json)
 - SessionStart hook that injects skills + runs `bd prime` (subsumes `bd setup claude`)
 - Duplicate hook detection — warns if `bd setup claude` hooks are still installed
@@ -48,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `docs/upstream-reference/` — key design docs from upstream (skills improvements, document review system)
 
 ### Changed
+
 - All 14 Superpowers skills: replaced TodoWrite with `bd` commands throughout
 - `using-superpowers` flowchart: TodoWrite nodes → `bd create` nodes
 - `subagent-driven-development` flowchart: TodoWrite → epic/child bead lifecycle
@@ -59,10 +62,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `CLAUDE.md` and `AGENTS.md`: rewritten for plugin context
 
 ### Removed
+
 - All active TodoWrite references (2 prohibition references retained: "Do NOT use TodoWrite")
 - Upstream community management files (CODE_OF_CONDUCT, issue templates, funding)
 - Platform-specific files for Cursor, Codex, OpenCode, Gemini (Claude Code only)
 
 ### Attribution
+
 - Superpowers skills: [obra/superpowers](https://github.com/obra/superpowers) by Jesse Vincent (MIT)
 - Beads issue tracker: [gastownhall/beads](https://github.com/gastownhall/beads) by Steve Yegge (MIT)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,14 @@
 
 This project IS a Claude Code marketplace plugin that merges [Superpowers](https://github.com/obra/superpowers) skills (v5.0.7) with [Beads](https://github.com/gastownhall/beads) issue tracking (v1.0.0).
 
-**Repository:** https://github.com/DollarDill/beads-superpowers
+**Repository:** <https://github.com/DollarDill/beads-superpowers>
 **Version:** 0.1.0
 **License:** MIT (fork of obra/superpowers, also MIT)
 
 ## Project Context
 
 This plugin gives AI coding agents two things simultaneously:
+
 1. **Process discipline** — 15 composable skills enforcing TDD, brainstorming, systematic debugging, two-stage code review, and verification
 2. **Persistent memory** — Every task is a bead tracked in a Dolt-backed database that survives across sessions
 
@@ -16,7 +17,7 @@ The key modification from upstream superpowers: every `TodoWrite` reference has 
 
 ## Plugin Structure
 
-```
+```text
 .claude-plugin/
   plugin.json              # Plugin manifest (auto-discovered by Claude Code)
   marketplace.json         # Marketplace config for plugin discovery
@@ -61,7 +62,7 @@ This plugin uses `bd` (beads) for ALL task tracking.
 
 ### GitHub Issue Sync
 
-This project syncs beads to GitHub Issues via `bd github sync`. Issues appear at https://github.com/DollarDill/beads-superpowers/issues.
+This project syncs beads to GitHub Issues via `bd github sync`. Issues appear at <https://github.com/DollarDill/beads-superpowers/issues>.
 
 ```bash
 bd github sync              # Push all beads to GitHub Issues
@@ -69,6 +70,7 @@ bd github status            # Check sync configuration
 ```
 
 GitHub sync is configured via:
+
 - `bd config set github.token <token>` (or `GITHUB_TOKEN` env var)
 - `bd config set github.repository DollarDill/beads-superpowers`
 
@@ -101,12 +103,14 @@ If `bd setup claude` hooks are installed in `.claude/settings.json`, this plugin
 ### Adding a New Skill
 
 1. Create `skills/<skill-name>/SKILL.md` with YAML frontmatter:
+
    ```yaml
    ---
    name: skill-name
    description: When to use this skill (trigger condition, not workflow summary)
    ---
    ```
+
 2. Make it beads-aware: use `bd create`/`bd close`/`bd ready` for task tracking
 3. If it has a checklist, create beads per checklist item
 4. Update README.md skills table and CHANGELOG.md
@@ -160,11 +164,13 @@ cd tests/claude-code && ./run-skill-tests.sh --integration
 ## Version Management
 
 Version is declared in 3 files that must stay in sync:
+
 - `package.json`
 - `.claude-plugin/plugin.json`
 - `.claude-plugin/marketplace.json`
 
 Use `scripts/bump-version.sh` to update all at once:
+
 ```bash
 ./scripts/bump-version.sh 0.2.0        # Bump to new version
 ./scripts/bump-version.sh --check      # Detect version drift

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,118 @@
+# Contributing to beads-superpowers
+
+Thanks for considering a contribution. This project is a small, focused
+Claude Code plugin — issues and PRs are welcome, especially around skill
+content, hook portability, and beads integration polish.
+
+## Quick start for contributors
+
+```bash
+# 1. Fork on GitHub, then clone your fork
+git clone git@github.com:<your-user>/beads-superpowers.git
+cd beads-superpowers
+
+# 2. Create a feature branch
+git switch -c feat/my-improvement
+
+# 3. Make your changes (see "Making changes" below)
+
+# 4. Lint locally before pushing
+npx markdownlint-cli2 "**/*.md"
+
+# 5. Push and open a PR against main
+git push -u origin feat/my-improvement
+gh pr create
+```
+
+## Project conventions
+
+This project uses [`bd` (beads)](https://github.com/gastownhall/beads) for
+all task tracking and writes commit messages with conventional-commit
+prefixes (`feat:`, `fix:`, `docs:`, `ci:`, `chore:`, `build:`).
+
+- **Branches:** Use a descriptive branch name like `feat/<short-name>` or
+  `fix/<short-name>`. Default branch is `main`.
+- **Commits:** Small, focused commits. Tests, code, and docs land together
+  when they belong together.
+- **Skills:** Markdown only. No TodoWrite. No softening of bright-line
+  rules. See the "Modifying Skills" section in `CLAUDE.md`.
+
+## Making changes
+
+### Adding or modifying a skill
+
+1. Read the existing skill closest to what you want — copy its tone and
+   structure
+2. Use `bd` commands for task tracking inside the skill
+3. Do **not** add TodoWrite references
+4. Do **not** remove anti-rationalization tables, Iron Laws, or Red Flags
+5. Update `README.md` skill table and `CHANGELOG.md`
+
+### Modifying hooks or scripts
+
+The session-start hook is bash on Unix, batch on Windows (polyglot via
+`run-hook.cmd`). Test on both if you can. See `docs/windows/polyglot-hooks.md`.
+
+### Modifying plugin manifests
+
+Three files must stay in sync:
+
+- `.claude-plugin/plugin.json`
+- `.claude-plugin/marketplace.json`
+- `package.json`
+
+Use the helper script:
+
+```bash
+./scripts/bump-version.sh 0.2.0   # Bump to a new version
+./scripts/bump-version.sh --check # Detect drift
+```
+
+## Cache sync during development
+
+When you edit skills locally, the installed plugin cache at
+`~/.claude/plugins/cache/beads-superpowers-marketplace/beads-superpowers/0.1.0/`
+goes stale. Symlink the cache to your dev checkout once and you're done:
+
+```bash
+rm -rf ~/.claude/plugins/cache/beads-superpowers-marketplace/beads-superpowers/0.1.0
+ln -s ~/workplace/beads-superpowers \
+  ~/.claude/plugins/cache/beads-superpowers-marketplace/beads-superpowers/0.1.0
+```
+
+## Tests
+
+```bash
+# Fast tests (skill content verification, ~2 min)
+cd tests/claude-code && ./run-skill-tests.sh
+
+# Integration tests (full workflow execution, 10-30 min)
+cd tests/claude-code && ./run-skill-tests.sh --integration
+```
+
+## Pull request checklist
+
+The PR template auto-populates this — read it before you push:
+
+- [ ] CI passes locally (`npx markdownlint-cli2 "**/*.md"`)
+- [ ] No TodoWrite references in skills
+- [ ] Anti-rationalization tables, Iron Laws, Red Flags preserved
+- [ ] Version bumped in all 3 manifests if metadata changed
+- [ ] `CHANGELOG.md` updated under `## [Unreleased]`
+- [ ] `README.md` updated if user-facing behaviour changed
+
+## Code of conduct
+
+Be kind. Assume good intent. Disagree about technical things directly and
+respectfully. We do not have a separate CODE_OF_CONDUCT document — the
+default is "act like a professional engineer."
+
+## Reporting security issues
+
+Please follow the policy in [`SECURITY.md`](SECURITY.md). Do **not** open
+public issues for security vulnerabilities.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under
+the MIT License (see [`LICENSE`](LICENSE)).

--- a/README.md
+++ b/README.md
@@ -1,80 +1,73 @@
-# beads-superpowers
+<p align="center">
+  <img src="assets/banner.svg" alt="beads-superpowers — Process discipline and persistent memory for AI coding agents" width="100%" />
+</p>
 
-**Superpowers skills + Beads issue tracking** — a Claude Code plugin that gives AI coding agents a complete, persistent development workflow.
+<p align="center">
+  <em>Process discipline and persistent memory for AI coding agents.</em>
+</p>
 
-Every task is a bead. Every session starts with context. Every session ends with a push.
+<p align="center">
+  <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+  <a href=".claude-plugin/plugin.json"><img alt="Plugin version" src="https://img.shields.io/badge/plugin-v0.1.1-indigo.svg"></a>
+  <a href="https://github.com/DollarDill/beads-superpowers/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/DollarDill/beads-superpowers/actions/workflows/ci.yml/badge.svg?branch=main"></a>
+  <a href="https://github.com/DollarDill/beads-superpowers/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/DollarDill/beads-superpowers?style=social"></a>
+</p>
 
-## What Is This?
+---
 
-This plugin merges two proven systems into one:
+<table>
+<tr>
+<td width="50%" valign="top">
 
-- **[Superpowers](https://github.com/obra/superpowers)** (v5.0.7) — 15 composable skills that enforce professional software development workflows: brainstorming, TDD, systematic debugging, two-stage code review, and more. Created by Jesse Vincent.
-- **[Beads](https://github.com/gastownhall/beads)** (v1.0.0) — A persistent, Dolt-backed issue tracker designed as memory for AI coding agents. Hash-based IDs, dependency graphs, and cross-session persistence. Created by Steve Yegge.
-
-The result: skills that don't just tell agents *how* to work — they give agents a persistent ledger to track *what* they're working on, across sessions, with full audit trails and dependency awareness.
-
-## Why?
-
-AI coding agents have two problems:
-
-1. **No process discipline.** Without explicit workflow enforcement, agents skip tests, rush to code, and claim work is done without verification. Superpowers solves this with 15 mandatory skills backed by empirically-tested anti-rationalization techniques.
-
-2. **No persistent memory.** When a session ends, todo lists vanish. Task context disappears. The next session starts blind. Beads solves this with a version-controlled SQL database that survives across sessions, agents, and projects.
-
-Neither system alone is complete. Together, they are.
-
-## Quick Start
-
-### Prerequisites
-
-- [Claude Code](https://claude.ai/claude-code) installed
-- [Beads](https://github.com/gastownhall/beads) installed (`brew install beads` or `npm install -g @beads/bd`)
-
-### Install the Plugin
+## Try it in 60 seconds
 
 ```bash
-# Step 1: Add the marketplace (one-time setup)
+# Add the marketplace
 claude plugin marketplace add DollarDill/beads-superpowers
 
-# Step 2: Install the plugin
+# Install the plugin
 claude plugin install beads-superpowers@beads-superpowers-marketplace
-```
 
-> **Note:** You can also run these as slash commands inside Claude Code: `/plugin marketplace add DollarDill/beads-superpowers` and `/plugin install beads-superpowers@beads-superpowers-marketplace`
-
-### Initialize Beads in Your Project
-
-```bash
+# In any project
 cd your-project
 bd init
 ```
 
-### Remove Duplicate Hooks (Important)
+In Claude Code, run `/skills` and you should see 15 skills prefixed with `beads-superpowers:`.
 
-The plugin's SessionStart hook already runs `bd prime`. If you previously ran `bd setup claude`, remove the duplicate hooks:
+<details>
+<summary>If you previously ran <code>bd setup claude</code></summary>
+
+The plugin's SessionStart hook already runs `bd prime`. Remove the duplicate hooks:
 
 ```bash
 bd setup claude --remove
 ```
 
-If you skip this step, the plugin will detect the duplication and warn you.
+</details>
 
-### Verify Installation
+</td>
+<td width="50%" valign="top">
 
-```bash
-# Check plugin is loaded (in Claude Code)
-/skills
+## Why it exists
 
-# You should see skills prefixed with beads-superpowers:
-#   beads-superpowers:brainstorming
-#   beads-superpowers:test-driven-development
-#   beads-superpowers:systematic-debugging
-#   ... (15 skills total)
-```
+AI coding agents have two recurring failure modes:
 
-## How It Works
+1. **No process discipline.** They skip tests, rush to code, and claim work is done without verification.
+2. **No persistent memory.** Todo lists vanish when a session ends. The next session starts blind.
 
-### Session Lifecycle
+**beads-superpowers** merges two upstream systems to solve both at once:
+
+- **[Superpowers](https://github.com/obra/superpowers)** by Jesse Vincent — 15 mandatory skills enforcing TDD, brainstorming, systematic debugging, and two-stage code review.
+- **[Beads](https://github.com/gastownhall/beads)** by Steve Yegge — a Dolt-backed issue tracker that survives across sessions, agents, and projects.
+
+The result: skills that don't just tell agents *how* to work — they give agents a persistent ledger to track *what* they're working on.
+
+</td>
+</tr>
+</table>
+
+## How it works
 
 ```text
 Session Start
@@ -103,47 +96,15 @@ Land the Plane (mandatory session close)
   └── git status (verify clean state)
 ```
 
-### Every Task Is a Bead
-
-When an agent executes an implementation plan, each task becomes a bead:
-
-```bash
-# Plan has 5 tasks → 5 beads created
-bd create "Epic: Authentication System" -t epic -p 2
-bd create "Task 1: Login endpoint" -t task --parent <epic-id>
-bd create "Task 2: Session management" -t task --parent <epic-id>
-bd create "Task 3: JWT middleware" -t task --parent <epic-id>
-bd dep add <task-3-id> <task-1-id>    # Task 3 depends on Task 1
-
-# Agent works through tasks
-bd update <task-1-id> --claim         # Start work
-# ... implement, test, review ...
-bd close <task-1-id> --reason "Implemented login with bcrypt hashing"
-
-# Check what's next
-bd ready --parent <epic-id>           # Shows unblocked tasks
-```
-
-### Skills Are Mandatory, Not Optional
-
 The `using-superpowers` skill (loaded at every session start) enforces:
 
 > **IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.**
 
-Skills are not suggestions. They use bright-line rules, anti-rationalization tables, and empirically-tested enforcement language. See [docs/METHODOLOGY.md](docs/METHODOLOGY.md) for the research basis.
+Skills are not suggestions. They use bright-line rules, anti-rationalization tables, and empirically-tested enforcement language. See [`docs/METHODOLOGY.md`](docs/METHODOLOGY.md) for the research basis.
 
-## Skills Reference
+## Skills reference
 
-### The Happy Path Pipeline
-
-```text
-brainstorming → writing-plans → subagent-driven-development → finishing-a-development-branch
-                                 (or executing-plans)
-```
-
-### All 15 Skills
-
-| Skill | Category | When to Use |
+| Skill | Category | When to use |
 |-------|----------|-------------|
 | **using-superpowers** | Meta | Every session start — routes to the right skill |
 | **brainstorming** | Design | Before any creative work — explores design before code |
@@ -161,9 +122,9 @@ brainstorming → writing-plans → subagent-driven-development → finishing-a-
 | **writing-skills** | Meta | Creating or modifying skills — TDD for process docs |
 | **auditing-upstream-drift** | Meta | Periodic audit for staleness vs upstream superpowers and beads |
 
-### Beads Commands Used in Skills
+### Beads commands used in skills
 
-| Action | Command | Used In |
+| Action | Command | Used in |
 |--------|---------|---------|
 | Create epic | `bd create "Epic: name" -t epic` | subagent-driven-dev, executing-plans |
 | Create task | `bd create "Task: name" -t task --parent <epic>` | subagent-driven-dev, executing-plans |
@@ -175,91 +136,31 @@ brainstorming → writing-plans → subagent-driven-development → finishing-a-
 | Sync to remote | `bd dolt push` | finishing-a-development-branch |
 | Session context | `bd prime` | SessionStart hook (automatic) |
 
-## Project Structure
+## Architecture
 
-```text
-beads-superpowers/
-├── .claude-plugin/
-│   └── plugin.json              # Plugin manifest (v0.1.0)
-├── hooks/
-│   ├── hooks.json               # SessionStart hook registration
-│   ├── session-start            # Injects skills + runs bd prime
-│   └── run-hook.cmd             # Windows polyglot wrapper
-├── skills/
-│   ├── brainstorming/           # 3 files — Socratic design refinement
-│   ├── dispatching-parallel-agents/  # 1 file — Concurrent subagent workflows
-│   ├── executing-plans/         # 1 file — Batch execution with checkpoints
-│   ├── finishing-a-development-branch/  # 1 file — Merge/PR + Land the Plane
-│   ├── receiving-code-review/   # 1 file — Anti-sycophancy review reception
-│   ├── requesting-code-review/  # 2 files — Review dispatch
-│   ├── subagent-driven-development/  # 4 files — Two-stage review orchestration
-│   ├── systematic-debugging/    # 11 files — 4-phase root cause analysis
-│   ├── test-driven-development/ # 2 files — RED-GREEN-REFACTOR
-│   ├── using-git-worktrees/     # 1 file — Isolated development branches
-│   ├── using-superpowers/       # 4 files — Bootstrap + beads awareness
-│   ├── verification-before-completion/  # 1 file — Evidence before claims
-│   ├── writing-plans/           # 2 files — Detailed implementation plans
-│   ├── writing-skills/          # 6 files — Skill creation meta-skill
-│   └── auditing-upstream-drift/ # 1 file  — Upstream staleness detection
-├── agents/
-│   └── code-reviewer.md         # Senior code reviewer agent
-├── commands/
-│   ├── brainstorm.md            # Deprecated → use brainstorming skill
-│   ├── execute-plan.md          # Deprecated → use executing-plans skill
-│   └── write-plan.md            # Deprecated → use writing-plans skill
-├── docs/
-│   ├── METHODOLOGY.md           # Design philosophy and research basis
-│   ├── SETUP-GUIDE.md           # Detailed installation and configuration
-│   ├── testing.md               # Test methodology
-│   ├── windows/                 # Cross-platform hook docs
-│   └── upstream-reference/      # Key design docs from upstream
-├── tests/
-│   ├── brainstorm-server/       # WebSocket server tests
-│   ├── claude-code/             # Claude Code integration tests
-│   ├── explicit-skill-requests/ # Skill explicit invocation tests
-│   ├── skill-triggering/        # Automatic skill detection tests
-│   └── subagent-driven-dev/     # End-to-end workflow tests
-├── scripts/
-│   └── bump-version.sh          # Version management across manifests
-├── package.json
-├── CLAUDE.md                    # Plugin development instructions
-├── AGENTS.md                    # Agent instructions
-├── LICENSE                      # MIT License
-└── README.md                    # This file
+```mermaid
+flowchart TB
+    User[User prompt] --> Orchestrator
+    subgraph Orchestrator [Main Agent — orchestrator-only beads]
+        SP[using-superpowers skill]
+        BD[bd prime — beads context]
+        SP --> Routing{Route to skill}
+    end
+    Routing -->|design| Brainstorm[brainstorming]
+    Routing -->|plan| WP[writing-plans]
+    Routing -->|execute| SDD[subagent-driven-development]
+    Routing -->|debug| Debug[systematic-debugging]
+    SDD --> Sub1[Subagent 1: Task A]
+    SDD --> Sub2[Subagent 2: Task B]
+    Sub1 -->|results| Review[Two-stage review]
+    Sub2 -->|results| Review
+    Review --> Close[bd close + bd dolt push]
+    Close --> Land[Land the Plane: git push]
 ```
 
-## Development: Keeping Installed Plugin in Sync
+The orchestrator is the only agent that touches beads. Subagents focus on implementation and have no concurrent bead-conflict surface. The two-stage review catches both spec deviation (first-stage spec reviewer) and code-quality issues (second-stage code reviewer) before any task is marked complete.
 
-When you edit skills in this repo, the installed plugin cache goes stale. Two options:
-
-### Option A: Symlink (Recommended)
-
-One-time setup — source changes take effect on next Claude Code restart.
-
-```bash
-rm -rf ~/.claude/plugins/cache/beads-superpowers-marketplace/beads-superpowers/0.1.0
-ln -s ~/workplace/beads-superpowers \
-  ~/.claude/plugins/cache/beads-superpowers-marketplace/beads-superpowers/0.1.0
-```
-
-### Option B: Nuke Cache
-
-Quick one-shot refresh — Claude Code re-copies from marketplace on next start.
-
-```bash
-rm -rf ~/.claude/plugins/cache/beads-superpowers-marketplace/beads-superpowers/
-```
-
-### Verify Sync
-
-```bash
-# Should print nothing if in sync
-diff -rq skills/ ~/.claude/plugins/cache/beads-superpowers-marketplace/beads-superpowers/0.1.0/skills/
-```
-
-> **Note:** `claude plugin update` exists but has a [cache invalidation bug](https://github.com/anthropics/claude-code/issues/14061). Use the symlink approach instead.
-
-## Key Design Decisions
+## Design decisions
 
 | Decision | Rationale |
 |----------|-----------|
@@ -269,6 +170,51 @@ diff -rq skills/ ~/.claude/plugins/cache/beads-superpowers-marketplace/beads-sup
 | **Land the Plane in finishing skill** | Session close protocol lives in the terminal skill, not a separate skill. Every pipeline path ends here. |
 | **Skills are Markdown, not code** | Pure documentation — no build step, no dependencies, works on any platform with a file system. |
 
+## Project structure
+
+```text
+beads-superpowers/
+├── .claude-plugin/         Plugin manifests (auto-discovered by Claude Code)
+├── .github/                CI workflow, Dependabot, issue/PR templates
+├── assets/                 README banner SVG
+├── hooks/                  SessionStart hook (bash + Windows polyglot wrapper)
+├── skills/                 15 beads-native skills
+├── agents/                 code-reviewer agent
+├── commands/               Deprecated slash commands (will be removed in v0.2.0)
+├── docs/                   METHODOLOGY, SETUP-GUIDE, testing, upstream-reference
+├── tests/                  Test infrastructure (5 suites)
+├── scripts/                bump-version.sh
+├── CHANGELOG.md
+├── CLAUDE.md               Plugin development instructions
+├── AGENTS.md               Agent instructions
+├── CONTRIBUTING.md         How to contribute
+├── SECURITY.md             Vulnerability reporting policy
+├── LICENSE                 MIT
+└── README.md               This file
+```
+
+For a deeper directory listing, see [`docs/SETUP-GUIDE.md`](docs/SETUP-GUIDE.md).
+
+## Development
+
+When you edit skills in this repo, the installed plugin cache goes stale. The simplest fix is a one-time symlink:
+
+```bash
+rm -rf ~/.claude/plugins/cache/beads-superpowers-marketplace/beads-superpowers/0.1.1
+ln -s ~/workplace/beads-superpowers \
+  ~/.claude/plugins/cache/beads-superpowers-marketplace/beads-superpowers/0.1.1
+```
+
+Verify sync:
+
+```bash
+diff -rq skills/ ~/.claude/plugins/cache/beads-superpowers-marketplace/beads-superpowers/0.1.1/skills/
+```
+
+> `claude plugin update` exists but has a [cache invalidation bug](https://github.com/anthropics/claude-code/issues/14061). Use the symlink approach instead.
+
+For the full contributor guide, see [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
 ## Attribution
 
 - **Superpowers skills** — [obra/superpowers](https://github.com/obra/superpowers) by Jesse Vincent (MIT License)
@@ -277,4 +223,4 @@ diff -rq skills/ ~/.claude/plugins/cache/beads-superpowers-marketplace/beads-sup
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you skip this step, the plugin will detect the duplication and warn you.
 
 ### Session Lifecycle
 
-```
+```text
 Session Start
   │
   ▼
@@ -136,7 +136,7 @@ Skills are not suggestions. They use bright-line rules, anti-rationalization tab
 
 ### The Happy Path Pipeline
 
-```
+```text
 brainstorming → writing-plans → subagent-driven-development → finishing-a-development-branch
                                  (or executing-plans)
 ```
@@ -177,7 +177,7 @@ brainstorming → writing-plans → subagent-driven-development → finishing-a-
 
 ## Project Structure
 
-```
+```text
 beads-superpowers/
 ├── .claude-plugin/
 │   └── plugin.json              # Plugin manifest (v0.1.0)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
-  <a href=".claude-plugin/plugin.json"><img alt="Plugin version" src="https://img.shields.io/badge/plugin-v0.1.1-indigo.svg"></a>
+  <a href=".claude-plugin/plugin.json"><img alt="Plugin version" src="https://img.shields.io/badge/plugin-v0.1.1-4f46e5.svg"></a>
   <a href="https://github.com/DollarDill/beads-superpowers/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/DollarDill/beads-superpowers/actions/workflows/ci.yml/badge.svg?branch=main"></a>
   <a href="https://github.com/DollarDill/beads-superpowers/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/DollarDill/beads-superpowers?style=social"></a>
 </p>
@@ -145,6 +145,7 @@ flowchart TB
         SP[using-superpowers skill]
         BD[bd prime — beads context]
         SP --> Routing{Route to skill}
+        BD --> Routing
     end
     Routing -->|design| Brainstorm[brainstorming]
     Routing -->|plan| WP[writing-plans]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,59 @@
+# Security Policy
+
+## Supported versions
+
+This project is in active development. Security fixes apply only to the
+latest released version.
+
+| Version | Supported |
+|---------|-----------|
+| 0.1.x   | ✅        |
+| < 0.1   | ❌        |
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub
+issues, discussions, or pull requests.**
+
+Instead, use GitHub's private vulnerability reporting:
+
+1. Navigate to the [Security tab](https://github.com/DollarDill/beads-superpowers/security)
+2. Click **Report a vulnerability**
+3. Fill in the advisory form with as much detail as you can provide
+
+GitHub will notify the maintainer privately and create a draft advisory.
+
+If you cannot use GitHub's private reporting, email the maintainer directly
+via the contact details on [DollarDill's GitHub profile](https://github.com/DollarDill).
+
+## What to include
+
+- A description of the vulnerability and its impact
+- Steps to reproduce — ideally a minimal repro
+- The version of `beads-superpowers` you tested against
+- Whether the vulnerability has been disclosed elsewhere
+
+## Response timeline
+
+- **Initial acknowledgement:** within 5 business days
+- **Triage and severity assessment:** within 10 business days
+- **Patch or mitigation:** depends on severity; critical issues prioritised
+
+## Scope
+
+This policy covers:
+
+- The `beads-superpowers` plugin code (skills, hooks, scripts)
+- The `.github/` automation (CI workflow, Dependabot, templates)
+- The plugin manifests (`.claude-plugin/plugin.json`, `marketplace.json`)
+
+This policy does **not** cover:
+
+- Upstream [Superpowers](https://github.com/obra/superpowers) — report there
+- Upstream [Beads](https://github.com/gastownhall/beads) — report there
+- Claude Code itself — report at [anthropics/claude-code](https://github.com/anthropics/claude-code)
+
+## Recognition
+
+Reporters who follow this policy will be credited in the security advisory
+unless they request otherwise.

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 320" role="img" aria-label="beads-superpowers — Process discipline and persistent memory for AI coding agents">
+  <title>beads-superpowers</title>
+  <desc>Process discipline and persistent memory for AI coding agents</desc>
+
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1e1b4b"/>
+    </linearGradient>
+    <style>
+      .title  { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-weight: 700; fill: #ffffff; }
+      .rule   { stroke: #818cf8; stroke-width: 4; stroke-linecap: round; }
+      .tagline{ font-family: "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-weight: 400; fill: #cbd5e1; }
+      .accent { fill: none; stroke: #818cf8; stroke-width: 5; stroke-linejoin: round; }
+    </style>
+  </defs>
+
+  <rect width="1280" height="320" fill="url(#bg)"/>
+
+  <text x="80" y="140" class="title" font-size="64">beads-superpowers</text>
+  <line x1="80" y1="170" x2="640" y2="170" class="rule"/>
+  <text x="80" y="220" class="tagline" font-size="28">Process discipline + persistent memory</text>
+  <text x="80" y="258" class="tagline" font-size="28">for AI coding agents</text>
+
+  <g transform="translate(1080,120)">
+    <polygon class="accent" points="60,0 120,35 120,105 60,140 0,105 0,35"/>
+    <polygon class="accent" points="60,30 90,47 90,93 60,110 30,93 30,47"/>
+  </g>
+</svg>

--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -1,5 +1,11 @@
 ---
-description: "Deprecated - use the superpowers:brainstorming skill instead"
+description: DEPRECATED — use the brainstorming skill via the Skill tool instead
 ---
 
-Tell your human partner that this command is deprecated and will be removed in the next major release. They should ask you to use the "superpowers brainstorming" skill instead.
+# DEPRECATED — use the `brainstorming` skill instead
+
+This slash command is preserved for backward compatibility only.
+Use the `beads-superpowers:brainstorming` skill via Claude Code's
+`Skill` tool. The skill provides the full, current workflow.
+
+This stub will be removed in **v0.2.0**.

--- a/commands/execute-plan.md
+++ b/commands/execute-plan.md
@@ -1,5 +1,11 @@
 ---
-description: "Deprecated - use the superpowers:executing-plans skill instead"
+description: DEPRECATED — use the executing-plans skill via the Skill tool instead
 ---
 
-Tell your human partner that this command is deprecated and will be removed in the next major release. They should ask you to use the "superpowers executing-plans" skill instead.
+# DEPRECATED — use the `executing-plans` skill instead
+
+This slash command is preserved for backward compatibility only.
+Use the `beads-superpowers:executing-plans` skill via Claude Code's
+`Skill` tool. The skill provides the full, current workflow.
+
+This stub will be removed in **v0.2.0**.

--- a/commands/write-plan.md
+++ b/commands/write-plan.md
@@ -1,5 +1,11 @@
 ---
-description: "Deprecated - use the superpowers:writing-plans skill instead"
+description: DEPRECATED — use the writing-plans skill via the Skill tool instead
 ---
 
-Tell your human partner that this command is deprecated and will be removed in the next major release. They should ask you to use the "superpowers writing-plans" skill instead.
+# DEPRECATED — use the `writing-plans` skill instead
+
+This slash command is preserved for backward compatibility only.
+Use the `beads-superpowers:writing-plans` skill via Claude Code's
+`Skill` tool. The skill provides the full, current workflow.
+
+This stub will be removed in **v0.2.0**.

--- a/docs/METHODOLOGY.md
+++ b/docs/METHODOLOGY.md
@@ -9,6 +9,7 @@ AI coding agents in 2025-2026 face two fundamental problems that, until now, hav
 ### Problem 1: No Process Discipline
 
 Without explicit workflow enforcement, AI agents consistently:
+
 - Skip to coding before understanding the problem
 - Write implementation before tests
 - Claim work is "done" without running verification
@@ -21,6 +22,7 @@ Without explicit workflow enforcement, AI agents consistently:
 ### Problem 2: No Persistent Memory
 
 When an AI coding session ends:
+
 - Todo lists created with `TodoWrite` vanish entirely
 - Task dependencies are forgotten
 - Work-in-progress has no audit trail
@@ -28,6 +30,7 @@ When an AI coding session ends:
 - Learned conventions and preferences are lost
 
 **Beads** (by Steve Yegge) solved this with a Dolt-backed issue tracker that provides:
+
 - Hash-based IDs that work without central coordination
 - Cell-level merge for conflict-free multi-agent operation
 - `bd prime` context injection at every session start
@@ -86,6 +89,7 @@ The three subagent prompt files are deliberately not beads-aware. This is the **
 ### 1. Replace at Both Levels
 
 TodoWrite was used at two granularity levels in Superpowers:
+
 - **Task level**: Tracking plan tasks in execution skills
 - **Checklist level**: Tracking internal steps within a skill's own checklist
 
@@ -98,6 +102,7 @@ We replaced **both**. Even the brainstorming 9-step checklist and the writing-sk
 Beads' `bd setup claude` command installs SessionStart hooks that run `bd prime`. Our plugin's SessionStart hook also needs to inject the `using-superpowers` skill content. Having both fire would inject ~3-4k tokens of partially redundant context.
 
 **Solution:** The plugin's `hooks/session-start` script does both:
+
 1. Injects the `using-superpowers` skill (skill routing + beads awareness)
 2. Runs `bd prime` itself (beads CLI context + persistent memories)
 
@@ -106,12 +111,14 @@ It also detects if the `bd setup claude` hooks are still installed and warns the
 ### 3. Land the Plane in the Terminal Skill
 
 The "Land the Plane" session close protocol could live in:
+
 - A separate skill (`session-close`)
 - The user's CLAUDE.md
 - The terminal skill (`finishing-a-development-branch`)
 
 We chose the terminal skill because **every pipeline path already ends there**:
-```
+
+```text
 subagent-driven-development → finishing-a-development-branch
 executing-plans             → finishing-a-development-branch
 ```
@@ -133,6 +140,7 @@ The pattern: orchestrator creates bead → dispatches subagent → subagent impl
 Following Superpowers' zero-dependency philosophy, all skills are plain Markdown files with YAML frontmatter. No build step. No runtime dependencies. No code changes needed.
 
 This means:
+
 - The plugin works on any platform with a file system
 - Skills can be read, understood, and modified by humans
 - No version compatibility issues with runtimes
@@ -145,16 +153,19 @@ This means:
 The skill enforcement language is grounded in two research streams:
 
 **Cialdini (2021) — Influence Principles Applied to AI:**
+
 - **Authority**: Iron Laws and bright-line rules ("NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST")
 - **Consistency**: Once an agent starts following a skill, consistency pressure maintains compliance
 - **Scarcity**: "You cannot rationalize your way out of this" removes alternatives
 
 **Meincke et al. (2025) — AI Agent Compliance:**
+
 - Compliance **doubled from 33% to 72%** when using absolute rules over hedged guidance
 - Pre-emptive rationalization counters outperform reactive correction
 - Specific examples of non-compliance are more effective than generic warnings
 
 This is why every discipline-enforcing skill includes:
+
 - An **Iron Law** (absolute, memorable, no exceptions)
 - A **Red Flags table** (anticipated rationalizations with pre-loaded counter-arguments)
 - **Bright-line rules** (MUST/NEVER/NO EXCEPTIONS instead of "consider"/"prefer"/"try to")
@@ -201,7 +212,7 @@ By integrating beads into every skill, we ensure all seven memory types are popu
 
 ### What Happens When an Agent Receives a Feature Request
 
-```
+```text
 1. SessionStart hook fires
    ├── Loads using-superpowers skill (beads-aware routing)
    └── Runs bd prime (beads context + memories)
@@ -294,5 +305,6 @@ Every step is tracked. Every decision is auditable. Every session starts where t
 ### Analysis Documentation
 
 The complete research that informed this integration is available in `docs/`:
+
 - `01-system-architecture.md` through `05-comparison-and-insights.md` — Superpowers deep dive
 - `06-beads-system-architecture.md` through `09-beads-design-patterns.md` — Beads deep dive

--- a/docs/SETUP-GUIDE.md
+++ b/docs/SETUP-GUIDE.md
@@ -8,6 +8,7 @@
 
 1. **Claude Code** — Install from [claude.ai/claude-code](https://claude.ai/claude-code)
 2. **Beads** — Install the `bd` CLI:
+
    ```bash
    # Homebrew (macOS/Linux)
    brew install beads
@@ -42,7 +43,8 @@ claude plugin install beads-superpowers@beads-superpowers-marketplace
 ```
 
 You can also run these as slash commands inside an active Claude Code session:
-```
+
+```text
 /plugin marketplace add DollarDill/beads-superpowers
 /plugin install beads-superpowers@beads-superpowers-marketplace
 ```
@@ -100,6 +102,7 @@ bd init
 ```
 
 This creates:
+
 - `.beads/` directory with config, metadata, and git hooks
 - `CLAUDE.md` with beads instructions (will be superseded by the plugin)
 - `AGENTS.md` with agent instructions (will be superseded by the plugin)
@@ -175,6 +178,7 @@ This fires on every session start, clear, and compact event. The `hooks/session-
 4. **Outputs platform-specific JSON** — Claude Code, Cursor, and Copilot CLI each expect different formats
 
 The combined output (~2-3k tokens) provides the agent with:
+
 - Skill routing instructions (which skill to invoke when)
 - Beads awareness (key concepts, quick reference, rules)
 - Beads CLI context (commands, workflow, memories)
@@ -206,6 +210,7 @@ The hook outputs JSON in the correct format for each platform:
 ### Windows Support
 
 The `hooks/run-hook.cmd` file is a polyglot wrapper:
+
 - On Windows: `cmd.exe` runs the batch portion, which finds Git Bash and executes the hook
 - On Unix: The shell interprets the file as a bash script (`:` is a no-op)
 
@@ -244,7 +249,8 @@ To modify a skill's behaviour for your project:
 3. Or fork the plugin and modify skills directly
 
 **Instruction priority:**
-```
+
+```text
 1. User's CLAUDE.md instructions — HIGHEST
 2. Plugin skills — override default behaviour
 3. Default system prompt — LOWEST
@@ -255,6 +261,7 @@ To modify a skill's behaviour for your project:
 ### "bd: command not found"
 
 Beads is not installed. Install it:
+
 ```bash
 brew install beads
 # or
@@ -264,6 +271,7 @@ npm install -g @beads/bd
 ### "No .beads directory found"
 
 Initialize beads in your project:
+
 ```bash
 cd your-project
 bd init
@@ -272,6 +280,7 @@ bd init
 ### Skills not showing up
 
 Verify the plugin is installed:
+
 ```bash
 /plugins          # In Claude Code — should list beads-superpowers
 /skills           # Should show beads-superpowers: prefixed skills
@@ -280,6 +289,7 @@ Verify the plugin is installed:
 ### Duplicate context injection (double bd prime)
 
 The plugin's hook already runs `bd prime`. Remove the duplicate:
+
 ```bash
 bd setup claude --remove
 ```
@@ -287,6 +297,7 @@ bd setup claude --remove
 ### Hook not firing
 
 Check that the hook is executable:
+
 ```bash
 ls -la hooks/session-start
 # Should show -rwxr-xr-x
@@ -298,6 +309,7 @@ chmod +x hooks/session-start
 ### "bd dolt push" fails
 
 Set up a Dolt remote first:
+
 ```bash
 bd dolt remote add origin <url>
 ```
@@ -309,6 +321,7 @@ Or if you don't need remote sync, the push failure is harmless — beads still w
 If you see any active TodoWrite references in skills (not "Do NOT use TodoWrite"), report it as a bug. The migration should have caught all instances.
 
 Verify:
+
 ```bash
 grep -r "TodoWrite" skills/ | grep -v "Do NOT use" | grep -v "replaces"
 # Should return empty
@@ -348,6 +361,7 @@ claude plugin marketplace remove beads-superpowers-marketplace
 ### Restore bd setup claude Hooks (if desired)
 
 If you want to go back to standalone beads without the plugin:
+
 ```bash
 bd setup claude
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,7 +10,7 @@ Testing skills that involve subagents, workflows, and complex interactions requi
 
 ## Test Structure
 
-```
+```text
 tests/
 ├── claude-code/
 │   ├── test-helpers.sh                    # Shared test utilities
@@ -67,7 +67,7 @@ The integration test verifies the `subagent-driven-development` skill correctly:
 
 ### Test Output
 
-```
+```text
 ========================================
  Integration Test: subagent-driven-development
 ========================================
@@ -184,6 +184,7 @@ ls -lt "$SESSION_DIR"/*.jsonl | head -5
 **Problem**: Skill not found when running headless tests
 
 **Solutions**:
+
 1. Ensure you're running FROM the beads-superpowers directory: `cd /path/to/beads-superpowers && tests/...`
 2. Check `~/.claude/settings.json` has `"beads-superpowers": true` in `enabledPlugins`
 3. Verify skill exists in `skills/` directory
@@ -193,6 +194,7 @@ ls -lt "$SESSION_DIR"/*.jsonl | head -5
 **Problem**: Claude blocked from writing files or accessing directories
 
 **Solutions**:
+
 1. Use `--permission-mode bypassPermissions` flag
 2. Use `--add-dir /path/to/temp/dir` to grant access to test directories
 3. Check file permissions on test directories
@@ -202,6 +204,7 @@ ls -lt "$SESSION_DIR"/*.jsonl | head -5
 **Problem**: Test takes too long and times out
 
 **Solutions**:
+
 1. Increase timeout: `timeout 1800 claude ...` (30 minutes)
 2. Check for infinite loops in skill logic
 3. Review subagent task complexity
@@ -211,6 +214,7 @@ ls -lt "$SESSION_DIR"/*.jsonl | head -5
 **Problem**: Can't find session transcript after test run
 
 **Solutions**:
+
 1. Check the correct project directory in `~/.claude/projects/`
 2. Use `find ~/.claude/projects -name "*.jsonl" -mmin -60` to find recent sessions
 3. Verify test actually ran (check for errors in test output)

--- a/docs/windows/polyglot-hooks.md
+++ b/docs/windows/polyglot-hooks.md
@@ -7,6 +7,7 @@ Claude Code plugins need hooks that work on Windows, macOS, and Linux. This docu
 ## The Problem
 
 Claude Code runs hook commands through the system's default shell:
+
 - **Windows**: CMD.exe
 - **macOS/Linux**: bash or sh
 
@@ -53,7 +54,7 @@ CMDBLOCK
 
 ## File Structure
 
-```
+```text
 hooks/
 ├── hooks.json           # Points to the .cmd wrapper
 ├── session-start.cmd    # Polyglot wrapper (cross-platform entry point)
@@ -85,11 +86,13 @@ Note: The path must be quoted because `${CLAUDE_PLUGIN_ROOT}` may contain spaces
 ## Requirements
 
 ### Windows
+
 - **Git for Windows** must be installed (provides `bash.exe` and `cygpath`)
 - Default installation path: `C:\Program Files\Git\bin\bash.exe`
 - If Git is installed elsewhere, the wrapper needs modification
 
 ### Unix (macOS/Linux)
+
 - Standard bash or sh shell
 - The `.cmd` file must have execute permission (`chmod +x`)
 
@@ -97,24 +100,28 @@ Note: The path must be quoted because `${CLAUDE_PLUGIN_ROOT}` may contain spaces
 
 Your actual hook logic goes in the `.sh` file. To ensure it works on Windows (via Git Bash):
 
-### Do:
+### Do
+
 - Use pure bash builtins when possible
 - Use `$(command)` instead of backticks
 - Quote all variable expansions: `"$VAR"`
 - Use `printf` or here-docs for output
 
-### Avoid:
+### Avoid
+
 - External commands that may not be in PATH (sed, awk, grep)
 - If you must use them, they're available in Git Bash but ensure PATH is set up (use `bash -l`)
 
 ### Example: JSON Escaping Without sed/awk
 
 Instead of:
+
 ```bash
 escaped=$(echo "$content" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | awk '{printf "%s\\n", $0}')
 ```
 
 Use pure bash:
+
 ```bash
 escape_for_json() {
     local input="$1"
@@ -140,6 +147,7 @@ escape_for_json() {
 For plugins with multiple hooks, you can create a generic wrapper that takes the script name as an argument:
 
 ### run-hook.cmd
+
 ```cmd
 : << 'CMDBLOCK'
 @echo off
@@ -157,6 +165,7 @@ shift
 ```
 
 ### hooks.json using the reusable wrapper
+
 ```json
 {
   "hooks": {
@@ -189,19 +198,25 @@ shift
 ## Troubleshooting
 
 ### "bash is not recognized"
+
 CMD can't find bash. The wrapper uses the full path `C:\Program Files\Git\bin\bash.exe`. If Git is installed elsewhere, update the path.
 
 ### "cygpath: command not found" or "dirname: command not found"
+
 Bash isn't running as a login shell. Ensure `-l` flag is used.
 
 ### Path has weird `\/` in it
+
 `${CLAUDE_PLUGIN_ROOT}` expanded to a Windows path ending with backslash, then `/hooks/...` was appended. Use `cygpath` to convert the entire path.
 
 ### Script opens in text editor instead of running
+
 The hooks.json is pointing directly to the `.sh` file. Point to the `.cmd` wrapper instead.
 
 ### Works in terminal but not as hook
+
 Claude Code may run hooks differently. Test by simulating the hook environment:
+
 ```powershell
 $env:CLAUDE_PLUGIN_ROOT = "C:\path\to\plugin"
 cmd /c "C:\path\to\plugin\hooks\session-start.cmd"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beads-superpowers",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Superpowers + Beads: skills and persistent issue tracking for AI agents"
 }

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -43,7 +43,7 @@ write_json_field() {
 # Read the list of declared files from config.
 # Outputs lines of "path<TAB>field"
 declared_files() {
-  jq -r '.files[] | "\(.path)\t\(.field)"' "$CONFIG"
+  jq -r '.files[] | "\(.path)\t\(.key)"' "$CONFIG"
 }
 
 # Read the audit exclude patterns from config.


### PR DESCRIPTION
## Summary

Tier 2 portfolio-grade polish pass on the repo. No skill content touched.

- Hero banner SVG + README rewrite with badges, dual-path block, and Mermaid architecture diagram
- New `.github/` infrastructure: CI (markdownlint + plugin.json validate), Dependabot, issue/PR templates, SECURITY.md, CONTRIBUTING.md
- `.markdownlint.json` + `.markdownlint-cli2.jsonc` (skills/, docs/upstream-reference/, tests/ excluded)
- Branch renamed `master` → `main`
- `SESSION-SUMMARY.md` working file gitignored under new `.sessions/` directory
- Deprecated `commands/` stubs rewritten with v0.2.0 removal warning
- Version bump 0.1.0 → 0.1.1 + CHANGELOG entry consolidating Unreleased
- `plugin.json` description rewritten to match GitHub repo description
- Bonus: fixed real bug in `scripts/bump-version.sh` (`.field` → `.key`)

## Test plan

- [ ] CI passes on first run (markdownlint + plugin.json validate)
- [ ] CI badge in README is green
- [ ] Mermaid diagram renders on GitHub
- [ ] Banner SVG renders in README and as social preview
- [ ] Dependabot config parses without errors in GitHub UI
- [ ] No `master` references remain in tracked files

Refs: portfolio-zek.6